### PR TITLE
Find python via the environment + finish python3 port

### DIFF
--- a/DD.py
+++ b/DD.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
+
 # $Id: DD.py,v 1.2 2001/11/05 19:53:33 zeller Exp $
 # Enhanced Delta Debugging class
 # Copyright (c) 1999, 2000, 2001 Andreas Zeller.

--- a/DD.py
+++ b/DD.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python
 # $Id: DD.py,v 1.2 2001/11/05 19:53:33 zeller Exp $
 # Enhanced Delta Debugging class
 # Copyright (c) 1999, 2000, 2001 Andreas Zeller.

--- a/Interlibmath/testCos.py
+++ b/Interlibmath/testCos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import math
 import sys

--- a/Interlibmath/testCos.py
+++ b/Interlibmath/testCos.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+
 import math
 import sys
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AM_PATH_PYTHON()
+AM_PATH_PYTHON([3])
 
 AC_CACHE_CHECK([verrou fma], vg_cv_verrou_fma,
   [AC_ARG_ENABLE(verrou-fma,

--- a/ddTest/ddCmp.py
+++ b/ddTest/ddCmp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 import sys

--- a/ddTest/ddCmp.py
+++ b/ddTest/ddCmp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import sys
@@ -9,11 +9,11 @@ import pickle
 
 
 def cmpNorm(ref, toCmp, ddCase):
-    print "norm"
+    print("norm")
     if "dd.sym" in ref:
         return ddCase.statusOfSymConfig(open(toCmp+"/path_exclude").readline())
     if "dd.line" in ref:
-        return ddCase.statusOfSourceConfig(ref+"/dd.exclude",open(toCmp+"/path_source").readline())
+        return ddCase.statusOfSourceConfig(ref+"/dd.exclude", open(toCmp+"/path_source").readline())
 if __name__=="__main__":
     if sys.argv[1]== sys.argv[2]:
         sys.exit(0)
@@ -22,7 +22,7 @@ if __name__=="__main__":
         ref=sys.argv[1]
         ddCase.unpickle(ref+"/dd.pickle")
         toCmp=sys.argv[2]
-        sys.exit(cmpNorm(ref, toCmp,ddCase))
+        sys.exit(cmpNorm(ref, toCmp, ddCase))
     
 
 

--- a/ddTest/ddRun.py
+++ b/ddTest/ddRun.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 
 import sys

--- a/ddTest/ddRun.py
+++ b/ddTest/ddRun.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import sys
@@ -11,10 +11,10 @@ class ddConfig:
         self.listOfFailure=listOfFailure
 
     def listOfSym(self):
-        return [("sym-"+str(i),"fake.so") for i in range(self.nbSym)]
+        return [("sym-"+str(i), "fake.so") for i in range(self.nbSym)]
 
     def listOfLine(self, excludeFile):
-        listOfSymExcluded=[int((line.split()[0]).replace("sym-","")) for line in ((open(excludeFile.strip(),"r")).readlines()) ]
+        listOfSymExcluded=[int((line.split()[0]).replace("sym-", "")) for line in ((open(excludeFile.strip(), "r")).readlines()) ]
         listOfSymIncluded=[i for i in range(self.nbSym) if i not in listOfSymExcluded]
         res=[]
         for sym in listOfSymIncluded:
@@ -23,57 +23,57 @@ class ddConfig:
                     for (lineIndex, failureLine) in listOfLine:
                             res+=[("sym"+str(sym)+".c", lineIndex, "sym-"+str(sym))]
                 
-        print "print listOfLine", res
+        print("print listOfLine", res)
         return res
         
     def pickle(self, fileName):
-        pickle.dump(self.listOfFailure,open(fileName,"w"))
+        pickle.dump(self.listOfFailure, open(fileName, "w"))
 #        f=open(fileName,"w")
 #        f.write(str(self.nb)+"\n")
 #        f.close()
 
-    def unpickle(self,fileName):
-        self.listOfFailure=pickle.load(open(fileName,"r"))
+    def unpickle(self, fileName):
+        self.listOfFailure=pickle.load(open(fileName, "r"))
         self.nbSym=len(self.listOfFailure)
 #        self.nb=int(f.readline())
 #        f.close()
 
-    def statusOfSymConfig(self,config):
-        print config
-        listOfLine=[int((line.split()[0]).replace("sym-","")) for line in ((open(config.strip(),"r")).readlines()) ]
-        print listOfLine
+    def statusOfSymConfig(self, config):
+        print(config)
+        listOfLine=[int((line.split()[0]).replace("sym-", "")) for line in ((open(config.strip(), "r")).readlines()) ]
+        print(listOfLine)
 
         for line in range(self.nbSym):
             if line not in listOfLine and self.listOfFailure[line][1]!=0:
                 return 1
         return 0
 
-    def statusOfSourceConfig(self,configSym, configLine):
-        print "configSym:", configSym
-        print "configLine:", configLine
-        print (open(configSym.strip(),"r")).readlines()
-        listOfSym=[int((line.split()[0]).replace("sym-","")) for line in ((open(configSym.strip(),"r")).readlines()) ]
-        print listOfSym
+    def statusOfSourceConfig(self, configSym, configLine):
+        print("configSym:", configSym)
+        print("configLine:", configLine)
+        print((open(configSym.strip(), "r")).readlines())
+        listOfSym=[int((line.split()[0]).replace("sym-", "")) for line in ((open(configSym.strip(), "r")).readlines()) ]
+        print(listOfSym)
 
-        configLineLines=[line.split() for line in  (open(configLine.strip(),"r")).readlines()]
-        configLineLines.remove(["__unknown__","0"])
-        print "configLineLines:",configLineLines
+        configLineLines=[line.split() for line in  (open(configLine.strip(), "r")).readlines()]
+        configLineLines.remove(["__unknown__", "0"])
+        print("configLineLines:", configLineLines)
         for sym in range(self.nbSym):
             if sym not in listOfSym and self.listOfFailure[sym][1]!=0:
-                print "sym:", sym
-                print "listofLineFailure :", self.listOfFailure[sym][2]
+                print("sym:", sym)
+                print("listofLineFailure :", self.listOfFailure[sym][2])
                 
                 
                 selectedConfigLines=[int(line[1]) for line in configLineLines if line[2]=="sym-"+str(sym) ]
-                print "selectedConfigLines:", selectedConfigLines
+                print("selectedConfigLines:", selectedConfigLines)
                 for (lineFailure, failure) in self.listOfFailure[sym][2]: 
                     if lineFailure in selectedConfigLines and failure :
-                        print "line return : ",lineFailure
+                        print("line return : ", lineFailure)
                         return 1
                 
                     
 
-        print "Oups"
+        print("Oups")
         return 0
 
     
@@ -81,11 +81,11 @@ class ddConfig:
         
 def generateFakeExclusion(ddCase):
     genExcludeFile=os.environ["VERROU_GEN_EXCLUDE"]
-    genExcludeFile=genExcludeFile.replace("%p","4242")
+    genExcludeFile=genExcludeFile.replace("%p", "4242")
     
     
-    f=open(genExcludeFile,"w")
-    for (sym,name,) in ddCase.listOfSym():
+    f=open(genExcludeFile, "w")
+    for (sym, name,) in ddCase.listOfSym():
         f.write(sym +"\t" + name+"\n")
     f.close()
 
@@ -93,13 +93,13 @@ def generateFakeSource(ddCase):
 
 
     genSourceFile=os.environ["VERROU_GEN_SOURCE"]
-    genSourceFile=genSourceFile.replace("%p","4242")
+    genSourceFile=genSourceFile.replace("%p", "4242")
 
     
     excludeFile= os.environ["VERROU_EXCLUDE"]
     
-    f=open(genSourceFile,"w")
-    for (source , line ,  symName) in ddCase.listOfLine(excludeFile):
+    f=open(genSourceFile, "w")
+    for (source, line,  symName) in ddCase.listOfLine(excludeFile):
         f.write(source +"\t" + str(line)+"\t"+symName+"\n")
         
     f.close()
@@ -107,7 +107,7 @@ def generateFakeSource(ddCase):
 
     
 def runRef(dir_path, ddCase):
-    print "ref"
+    print("ref")
     if "dd.sym" in dir_path:
         generateFakeExclusion(ddCase)
         ddCase.pickle(dir_path+"/dd.pickle")
@@ -118,25 +118,25 @@ def runRef(dir_path, ddCase):
         return 0
 
         
-def runNorm(dir_path,ddCase):
-    print "norm"
+def runNorm(dir_path, ddCase):
+    print("norm")
     if "dd.sym" in dir_path:
-        f=open(dir_path +"/path_exclude","w")
+        f=open(dir_path +"/path_exclude", "w")
         f.write(os.environ["VERROU_EXCLUDE"]+"\n")
         f.close()
         return 0
     if "dd.line" in dir_path:
-        f=open(dir_path+"/path_source","w")
+        f=open(dir_path+"/path_source", "w")
         f.write(os.environ["VERROU_SOURCE"]+"\n")
         f.close()
         
         
 if __name__=="__main__":
-    ddCase=ddConfig([(sym, max(0, sym-6),[(line, max(0, line-8)) for line in range(11) ] ) for sym in range(10)])
+    ddCase=ddConfig([(sym, max(0, sym-6), [(line, max(0, line-8)) for line in range(11) ] ) for sym in range(10)])
     if "ref" in sys.argv[1]:
-        sys.exit(runRef(sys.argv[1],ddCase))
+        sys.exit(runRef(sys.argv[1], ddCase))
     else:
-        sys.exit(runNorm(sys.argv[1],ddCase))
+        sys.exit(runNorm(sys.argv[1], ddCase))
     
 
 

--- a/ddTest/ddRun.py
+++ b/ddTest/ddRun.py
@@ -27,13 +27,13 @@ class ddConfig:
         return res
         
     def pickle(self, fileName):
-        pickle.dump(self.listOfFailure, open(fileName, "w"))
+        pickle.dump(self.listOfFailure, open(fileName, "wb"))
 #        f=open(fileName,"w")
 #        f.write(str(self.nb)+"\n")
 #        f.close()
 
     def unpickle(self, fileName):
-        self.listOfFailure=pickle.load(open(fileName, "r"))
+        self.listOfFailure=pickle.load(open(fileName, "rb"))
         self.nbSym=len(self.listOfFailure)
 #        self.nb=int(f.readline())
 #        f.close()

--- a/docs/update-vr-clo
+++ b/docs/update-vr-clo
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import subprocess

--- a/docs/update-vr-clo
+++ b/docs/update-vr-clo
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import subprocess
@@ -8,7 +8,8 @@ env = os.environ
 env["COLUMNS"] = "81"
 man = subprocess.Popen(["man", "./install/share/man/man1/valgrind.1"],
                        env = env,
-                       stdout = subprocess.PIPE)
+                       stdout = subprocess.PIPE,
+                       encoding = 'utf8')
 
 for line in man.stdout:
     if line.startswith("VERROU"):

--- a/unitTest/checkRounding/makefile
+++ b/unitTest/checkRounding/makefile
@@ -13,10 +13,10 @@ FLAGS2 = $(FLAGS) -mfpmath=sse -march=native -mfma -DTEST_FMA -DTEST_SSE
 
 run: run1 run2
 run1: $(EXEC1)
-	python runCheck.py $(EXEC1)
+	python3 runCheck.py $(EXEC1)
 
 run2: $(EXEC2)
-	python runCheck.py $(EXEC2)
+	python3 runCheck.py $(EXEC2)
 
 
 $(EXEC1): $(SOURCE)

--- a/unitTest/checkRounding/runCheck.py
+++ b/unitTest/checkRounding/runCheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/unitTest/checkRounding/runCheck.py
+++ b/unitTest/checkRounding/runCheck.py
@@ -99,7 +99,7 @@ def verrouCerrFilter(res):
     newRes=[]
     for line in res:
         newLine=line.replace(pidStr, "")
-        if newLine.startswith(" Simulating ") and newLine.endswith(" rounding mode\n"):
+        if newLine.startswith(" Simulating ") and newLine.endswith(" rounding mode"):
             continue
         if newLine.startswith(" First seed : "):
             continue

--- a/unitTest/checkRounding/runCheck.py
+++ b/unitTest/checkRounding/runCheck.py
@@ -26,19 +26,16 @@ def runCmd(cmd,expectedResult=0, printCmd=True, printCwd=True):
     if printCwd:
         print("Cwd:", os.getcwd())
     #lancement de la commande
-
-    resStd=[]
-    resErr=[]
     
-    process=sp.Popen(args=shlex.split(cmd), stdout=sp.PIPE, stderr=sp.PIPE)
-        
-    fd=process.stdout
-    fde=process.stderr
+    process=sp.Popen(args=shlex.split(cmd),
+                     stdout=sp.PIPE,
+                     stderr=sp.PIPE,
+                     encoding='utf8')
 
-    resStd=fd.readlines()
-    resErr=fde.readlines()
-    fd.close() 
-    fde.close()
+    (resStdStr, resErrStr)=process.communicate()
+
+    resStd=resStdStr.splitlines()
+    resErr=resErrStr.splitlines()
      
     error=process.wait()
 

--- a/unitTest/checkRounding/runCheck.py
+++ b/unitTest/checkRounding/runCheck.py
@@ -29,13 +29,12 @@ def runCmd(cmd,expectedResult=0, printCmd=True, printCwd=True):
     
     process=sp.Popen(args=shlex.split(cmd),
                      stdout=sp.PIPE,
-                     stderr=sp.PIPE,
-                     encoding='utf8')
+                     stderr=sp.PIPE)
 
     (resStdStr, resErrStr)=process.communicate()
 
-    resStd=resStdStr.splitlines()
-    resErr=resErrStr.splitlines()
+    resStd=resStdStr.encode().splitlines()
+    resErr=resErrStr.encode().splitlines()
      
     error=process.wait()
 

--- a/unitTest/checkRounding/runCheck.py
+++ b/unitTest/checkRounding/runCheck.py
@@ -33,8 +33,8 @@ def runCmd(cmd,expectedResult=0, printCmd=True, printCwd=True):
 
     (resStdStr, resErrStr)=process.communicate()
 
-    resStd=resStdStr.encode().splitlines()
-    resErr=resErrStr.encode().splitlines()
+    resStd=resStdStr.decode('utf8').splitlines()
+    resErr=resErrStr.decode('utf8').splitlines()
      
     error=process.wait()
 

--- a/unitTest/checkRounding/runCheck.py
+++ b/unitTest/checkRounding/runCheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import sys
@@ -7,30 +7,30 @@ import shlex
 import re
 
 stdRounding=["nearest", "toward_zero", "downward", "upward" ]
-valgrindRounding=stdRounding + ["random","average","float", "farthest","memcheck"]
+valgrindRounding=stdRounding + ["random", "average", "float", "farthest", "memcheck"]
 
 
 def printRes(res):
-    print "stdout:"
+    print("stdout:")
     for line in res[0 ]:
-        print line[0:-1]
-    print "cerr  :"
+        print(line[0:-1])
+    print("cerr  :")
     for line in res[1 ]:
-        print line[0:-1]
+        print(line[0:-1])
 
 
 def runCmd(cmd,expectedResult=0, printCmd=True, printCwd=True):    
     if printCmd:
-        print  "Cmd:", cmd
+        print("Cmd:", cmd)
 
     if printCwd:
-        print "Cwd:", os.getcwd()
+        print("Cwd:", os.getcwd())
     #lancement de la commande
 
     resStd=[]
     resErr=[]
     
-    process=sp.Popen(args=shlex.split(cmd),stdout=sp.PIPE, stderr=sp.PIPE)
+    process=sp.Popen(args=shlex.split(cmd), stdout=sp.PIPE, stderr=sp.PIPE)
         
     fd=process.stdout
     fde=process.stderr
@@ -47,8 +47,8 @@ def runCmd(cmd,expectedResult=0, printCmd=True, printCwd=True):
         msg = "Error with the execution of : " +cmd+"\n"
         msg+= "\t error is " +str(error) +"\n"
         msg+= "\t expectedResult is " +str(expectedResult)        
-        print msg
-        printRes((resStd,resErr))
+        print(msg)
+        printRes((resStd, resErr))
 
         
         sys.exit(42)
@@ -58,7 +58,7 @@ def runCmd(cmd,expectedResult=0, printCmd=True, printCwd=True):
         
 
 class cmdPrepare:
-    def __init__(self,arg):
+    def __init__(self, arg):
         self.valgrindPath=os.path.join(os.environ["INSTALLPATH"], "bin", "valgrind")
         self.execPath=arg
     
@@ -83,7 +83,7 @@ class cmdPrepare:
             return True
         if env=="valgrind" and rounding in valgrindRounding:
             return True
-        print "Failure in checkRounding"
+        print("Failure in checkRounding")
         sys.exit(-1)
 
 
@@ -91,9 +91,9 @@ class cmdPrepare:
 def generatePairOfAvailableComputation():
     res=[]
     for i in stdRounding:
-        res+=[("fenv" ,i)]
+        res+=[("fenv", i)]
     for i in valgrindRounding:
-        res+=[("valgrind" ,i)]
+        res+=[("valgrind", i)]
     return res
         
 
@@ -102,7 +102,7 @@ def verrouCerrFilter(res):
     # pidStr="==2958=="
     newRes=[]
     for line in res:
-        newLine=line.replace(pidStr,"")
+        newLine=line.replace(pidStr, "")
         if newLine.startswith(" Simulating ") and newLine.endswith(" rounding mode\n"):
             continue
         if newLine.startswith(" First seed : "):
@@ -114,7 +114,7 @@ def getDiff(outPut, testName):
     for line in outPut[0]:
         if line.startswith(testName+":"):
             return float(line.split()[-1])
-    print "unknown testName: ", testName    
+    print("unknown testName: ", testName)    
     return None
 
 
@@ -128,11 +128,11 @@ class errorCounter:
         self.warn=warn
 
 
-    def incOK(self,v):
+    def incOK(self, v):
         self.ok+=v
-    def incKO(self,v):
+    def incKO(self, v):
         self.ko+=v
-    def incWarn(self,v):
+    def incWarn(self, v):
         self.warn+=v
     def add(self, tupleV):
         self.ok  =tupleV[0]
@@ -144,43 +144,43 @@ class errorCounter:
         self.warn+= v.warn
         return self
     def printSummary(self):
-        print "error summary"
-        print "\tOK : "+str(self.ok)
-        print "\tKO : "+str(self.ko)
-        print "\tWarning : "+str(self.warn)
+        print("error summary")
+        print("\tOK : "+str(self.ok))
+        print("\tKO : "+str(self.ko))
+        print("\tWarning : "+str(self.warn))
         
 def checkVerrouInvariant(allResult):
-    ref=allResult[("valgrind" ,"nearest")][1]
+    ref=allResult[("valgrind", "nearest")][1]
     ko=0
     ok=0
     for rounding in valgrindRounding:        
-        if rounding in ["nearest","memcheck"]:
+        if rounding in ["nearest", "memcheck"]:
             #nearest : because it is the ref
             #memcheck : because it is not verrou
             continue
-        (cout,cerr)=allResult[("valgrind" ,rounding)]
+        (cout, cerr)=allResult[("valgrind", rounding)]
         if cerr!=ref:
-            print "KO : incoherent number of operation ("+rounding+")"
+            print("KO : incoherent number of operation ("+rounding+")")
             ko+=1
         else:
-            print "OK : coherent number of operation ("+rounding+")"
+            print("OK : coherent number of operation ("+rounding+")")
             ok+=1
-    return errorCounter(ok,ko,0)
+    return errorCounter(ok, ko, 0)
 
-def diffRes(res1,res2):    
+def diffRes(res1, res2):    
     if len(res1)!=len(res2):
-        print "Wrong number of line"
-        print "fenv", res1
-        print "val", res2
+        print("Wrong number of line")
+        print("fenv", res1)
+        print("val", res2)
         sys.exit(-1)
     else:
         acc=0
-        for i in xrange(len(res1)):
+        for i in range(len(res1)):
             line1=res1[i]
             line2=res2[i]
             if  line1 !=line2:
-                print "\tfenv: "+line1.strip()
-                print "\tfval: "+line2.strip()+"\n"
+                print("\tfenv: "+line1.strip())
+                print("\tfval: "+line2.strip()+"\n")
                 acc+=1
         return acc
 
@@ -188,15 +188,15 @@ def checkRoundingInvariant(allResult):
     ok=0
     ko=0
     for rounding in stdRounding:
-        fenvRes=(allResult["fenv",rounding])[0]
-        valRes=(allResult["valgrind",rounding])[0]
+        fenvRes=(allResult["fenv", rounding])[0]
+        valRes=(allResult["valgrind", rounding])[0]
         if fenvRes!=valRes:
-            print "KO : incoherent comparison between fenv and valgrind ("+rounding+")"            
-            ko+=diffRes(fenvRes,valRes)
+            print("KO : incoherent comparison between fenv and valgrind ("+rounding+")")            
+            ko+=diffRes(fenvRes, valRes)
         else:
             ok+=1
-            print "OK : coherent comparison between fenv and valgrind ("+rounding+")"
-    return errorCounter(ok,ko,0)
+            print("OK : coherent comparison between fenv and valgrind ("+rounding+")")
+    return errorCounter(ok, ko, 0)
 
 
 
@@ -209,22 +209,22 @@ def checkRoundingInvariant(allResult):
 class assertRounding:
     def __init__(self, testName):
         self.testName=testName
-        self.diff_nearestMemcheck=getDiff(allResult[("valgrind" ,"memcheck")],testName)
-        self.diff_nearestNative=getDiff(allResult[("fenv" ,"nearest")],testName)
-        self.diff_toward_zeroNative  =getDiff(allResult[("fenv" ,"toward_zero")],testName)
-        self.diff_downwardNative     =getDiff(allResult[("fenv" ,"downward")],testName)
-        self.diff_upwardNative       =getDiff(allResult[("fenv" ,"upward")],testName)
+        self.diff_nearestMemcheck=getDiff(allResult[("valgrind", "memcheck")], testName)
+        self.diff_nearestNative=getDiff(allResult[("fenv", "nearest")], testName)
+        self.diff_toward_zeroNative  =getDiff(allResult[("fenv", "toward_zero")], testName)
+        self.diff_downwardNative     =getDiff(allResult[("fenv", "downward")], testName)
+        self.diff_upwardNative       =getDiff(allResult[("fenv", "upward")], testName)
         
-        self.diff_nearest      =getDiff(allResult[("valgrind" ,"nearest")],testName)
-        self.diff_toward_zero  =getDiff(allResult[("valgrind" ,"toward_zero")],testName)
-        self.diff_downward     =getDiff(allResult[("valgrind" ,"downward")],testName)
-        self.diff_upward       =getDiff(allResult[("valgrind" ,"upward")],testName)
-        self.diff_float        =getDiff(allResult[("valgrind" ,"float")],testName)
-        self.diff_farthest     =getDiff(allResult[("valgrind" ,"farthest")],testName)
+        self.diff_nearest      =getDiff(allResult[("valgrind", "nearest")], testName)
+        self.diff_toward_zero  =getDiff(allResult[("valgrind", "toward_zero")], testName)
+        self.diff_downward     =getDiff(allResult[("valgrind", "downward")], testName)
+        self.diff_upward       =getDiff(allResult[("valgrind", "upward")], testName)
+        self.diff_float        =getDiff(allResult[("valgrind", "float")], testName)
+        self.diff_farthest     =getDiff(allResult[("valgrind", "farthest")], testName)
 
 
-        self.diff_random       =getDiff(allResult[("valgrind" ,"random")],testName)      
-        self.diff_average      =getDiff(allResult[("valgrind" ,"average")],testName)     
+        self.diff_random       =getDiff(allResult[("valgrind", "random")], testName)      
+        self.diff_average      =getDiff(allResult[("valgrind", "average")], testName)     
 
         self.KoStr="Warning"
         self.warnBool=True
@@ -232,26 +232,26 @@ class assertRounding:
         self.warn=0
         self.ko=0
 
-        self.assertEqual("nearestNative","nearestMemcheck")
+        self.assertEqual("nearestNative", "nearestMemcheck")
         if self.ok!=0:
             self.KoStr="KO"
             self.warnBool=False
 
-    def getValue(self,str1):
+    def getValue(self, str1):
         return eval("self.diff_"+str1)
 
-    def printKo(self,str):
-        print self.KoStr+" : "+self.testName+ " "+str
+    def printKo(self, str):
+        print(self.KoStr+" : "+self.testName+ " "+str)
         if self.warnBool:
             self.warn+=1
         else:
             self.ko+=1
             
-    def printOk(self,str):
-        print "OK : "+self.testName+ " "+str
+    def printOk(self, str):
+        print("OK : "+self.testName+ " "+str)
         self.ok+=1
 
-    def assertEqValue(self,str1, value):
+    def assertEqValue(self, str1, value):
         value1=eval("self.diff_"+str1)
         value2=value
         if value1!= value2:
@@ -260,7 +260,7 @@ class assertRounding:
             self.printOk(str1+ "="+str(value))
 
         
-    def assertEqual(self,str1,str2):
+    def assertEqual(self, str1, str2):
         value1= eval("self.diff_"+str1)
         value2= eval("self.diff_"+str2)            
 
@@ -269,7 +269,7 @@ class assertRounding:
         else:
             self.printOk(str1+ "="+str2)
 
-    def assertLeq(self,str1,str2):
+    def assertLeq(self, str1, str2):
         value1= eval("self.diff_"+str1)
         value2= eval("self.diff_"+str2)            
 
@@ -279,7 +279,7 @@ class assertRounding:
             self.printKo(str1+ ">"+str2 + " "+str(value1) + " " +str(value2))
 
         
-    def assertLess(self,str1,str2):
+    def assertLess(self, str1, str2):
         value1= eval("self.diff_"+str1)
         value2= eval("self.diff_"+str2)            
 
@@ -289,7 +289,7 @@ class assertRounding:
             self.printKo(str1+ ">="+str2 +  " "+str(value1) + " " +str(value2))
 
 
-    def assertAbsLess(self,str1,str2):
+    def assertAbsLess(self, str1, str2):
         value1= abs(eval("self.diff_"+str1))
         value2= abs(eval("self.diff_"+str2))
 
@@ -300,13 +300,13 @@ class assertRounding:
 
 
     def assertNative(self):
-        for rd in ["nearest","toward_zero", "downward","upward"]:
-            self.assertEqual(rd,rd+"Native")
+        for rd in ["nearest", "toward_zero", "downward", "upward"]:
+            self.assertEqual(rd, rd+"Native")
 
 
     
     
-def checkTestPositiveAndOptimistRandomVerrou(allResult,testList,typeTab=["<double>","<float>"]):
+def checkTestPositiveAndOptimistRandomVerrou(allResult,testList,typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -316,8 +316,8 @@ def checkTestPositiveAndOptimistRandomVerrou(allResult,testList,typeTab=["<doubl
 
             testCheck=assertRounding(testName)
             testCheck.assertNative()
-            testCheck.assertEqual("toward_zero","downward")
-            testCheck.assertLess("downward","upward")
+            testCheck.assertEqual("toward_zero", "downward")
+            testCheck.assertLess("downward", "upward")
             testCheck.assertLeq("downward", "nearest")
             testCheck.assertLeq("downward", "farthest")
             testCheck.assertLeq("farthest", "upward")
@@ -326,39 +326,39 @@ def checkTestPositiveAndOptimistRandomVerrou(allResult,testList,typeTab=["<doubl
             testCheck.assertLess("downward", "random")
             testCheck.assertLess("downward", "average")
 
-            testCheck.assertLess("random","upward")
-            testCheck.assertLess("average","upward")
+            testCheck.assertLess("random", "upward")
+            testCheck.assertLess("average", "upward")
 
-            testCheck.assertAbsLess("average","random")
-            testCheck.assertAbsLess("average","upward")
-            testCheck.assertAbsLess("average","downward")
-            testCheck.assertAbsLess("average","nearest")
+            testCheck.assertAbsLess("average", "random")
+            testCheck.assertAbsLess("average", "upward")
+            testCheck.assertAbsLess("average", "downward")
+            testCheck.assertAbsLess("average", "nearest")
 
             ok+=testCheck.ok
             ko+=testCheck.ko
             warn+=testCheck.warn
 
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
 
-def checkFloat(allResult,testList):
+def checkFloat(allResult, testList):
     ok=0
     warn=0
     ko=0
     for test in testList:
         testCheckFloat=assertRounding(test+"<float>")
         testCheckDouble=assertRounding(test+"<double>")
-        testCheckFloat.assertEqual("nearest","float")
-        testCheckDouble.assertEqValue("float",testCheckFloat.getValue("nearest"))
+        testCheckFloat.assertEqual("nearest", "float")
+        testCheckDouble.assertEqValue("float", testCheckFloat.getValue("nearest"))
         ok+=testCheckFloat.ok
         ko+=testCheckFloat.ko
         warn+=testCheckFloat.warn
         ok+=testCheckDouble.ok
         ko+=testCheckDouble.ko
         warn+=testCheckDouble.warn
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
-def checkTestNegativeAndOptimistRandomVerrou(allResult,testList,typeTab=["<double>","<float>"]):
+def checkTestNegativeAndOptimistRandomVerrou(allResult,testList,typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -368,8 +368,8 @@ def checkTestNegativeAndOptimistRandomVerrou(allResult,testList,typeTab=["<doubl
 
             testCheck=assertRounding(testName)
             testCheck.assertNative()
-            testCheck.assertEqual("toward_zero","upward")
-            testCheck.assertLess("downward","upward")
+            testCheck.assertEqual("toward_zero", "upward")
+            testCheck.assertLess("downward", "upward")
             testCheck.assertLeq("downward", "nearest")
             testCheck.assertLeq("nearest", "upward")
 
@@ -379,21 +379,21 @@ def checkTestNegativeAndOptimistRandomVerrou(allResult,testList,typeTab=["<doubl
             testCheck.assertLess("downward", "random")
             testCheck.assertLess("downward", "average")
             
-            testCheck.assertLess("random","upward")
-            testCheck.assertLess("average","upward")
+            testCheck.assertLess("random", "upward")
+            testCheck.assertLess("average", "upward")
 
-            testCheck.assertAbsLess("average","random")
-            testCheck.assertAbsLess("average","upward")
-            testCheck.assertAbsLess("average","downward")
-            testCheck.assertAbsLess("average","nearest")
+            testCheck.assertAbsLess("average", "random")
+            testCheck.assertAbsLess("average", "upward")
+            testCheck.assertAbsLess("average", "downward")
+            testCheck.assertAbsLess("average", "nearest")
 
             ok+=testCheck.ok
             ko+=testCheck.ko
             warn+=testCheck.warn
 
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
-def checkTestPositive(allResult,testList, typeTab=["<double>","<float>"]):
+def checkTestPositive(allResult,testList, typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -402,8 +402,8 @@ def checkTestPositive(allResult,testList, typeTab=["<double>","<float>"]):
         testName=test+RealType
         testCheck=assertRounding(testName)
         testCheck.assertNative()
-        testCheck.assertEqual("toward_zero","downward")
-        testCheck.assertLess("downward","upward")
+        testCheck.assertEqual("toward_zero", "downward")
+        testCheck.assertLess("downward", "upward")
         testCheck.assertLeq("downward", "nearest")
         testCheck.assertLeq("nearest", "upward")
 
@@ -413,16 +413,16 @@ def checkTestPositive(allResult,testList, typeTab=["<double>","<float>"]):
         testCheck.assertLess("downward", "random")
         testCheck.assertLess("downward", "average")
 
-        testCheck.assertLess("random","upward")
-        testCheck.assertLess("average","upward")
+        testCheck.assertLess("random", "upward")
+        testCheck.assertLess("average", "upward")
 
         ok+=testCheck.ok
         ko+=testCheck.ko
         warn+=testCheck.warn
         
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
         
-def checkTestNegative(allResult,testList,typeTab=["<double>","<float>"]):
+def checkTestNegative(allResult,testList,typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -432,8 +432,8 @@ def checkTestNegative(allResult,testList,typeTab=["<double>","<float>"]):
 
             testCheck=assertRounding(testName)
             testCheck.assertNative()
-            testCheck.assertEqual("toward_zero","upward")
-            testCheck.assertLess("downward","upward")
+            testCheck.assertEqual("toward_zero", "upward")
+            testCheck.assertLess("downward", "upward")
             testCheck.assertLeq("downward", "nearest")
             testCheck.assertLeq("nearest", "upward")
 
@@ -443,16 +443,16 @@ def checkTestNegative(allResult,testList,typeTab=["<double>","<float>"]):
             testCheck.assertLess("downward", "random")
             testCheck.assertLess("downward", "average")
 
-            testCheck.assertLess("random","upward")
-            testCheck.assertLess("average","upward")
+            testCheck.assertLess("random", "upward")
+            testCheck.assertLess("average", "upward")
 
             ok+=testCheck.ok
             ko+=testCheck.ko
             warn+=testCheck.warn
 
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
-def checkTestPositiveBetweenTwoValues(allResult,testList, typeTab=["<double>","<float>"]):
+def checkTestPositiveBetweenTwoValues(allResult,testList, typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -461,8 +461,8 @@ def checkTestPositiveBetweenTwoValues(allResult,testList, typeTab=["<double>","<
         testName=test+RealType
         testCheck=assertRounding(testName)
         testCheck.assertNative()
-        testCheck.assertEqual("toward_zero","downward")
-        testCheck.assertLess("downward","upward")
+        testCheck.assertEqual("toward_zero", "downward")
+        testCheck.assertLess("downward", "upward")
         testCheck.assertLeq("downward", "nearest")
         testCheck.assertLeq("nearest", "upward")
 
@@ -472,16 +472,16 @@ def checkTestPositiveBetweenTwoValues(allResult,testList, typeTab=["<double>","<
         testCheck.assertLeq("downward", "random")
         testCheck.assertLeq("downward", "average")
 
-        testCheck.assertLeq("random","upward")
-        testCheck.assertLeq("average","upward")
+        testCheck.assertLeq("random", "upward")
+        testCheck.assertLeq("average", "upward")
 
         ok+=testCheck.ok
         ko+=testCheck.ko
         warn+=testCheck.warn
 
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
-def checkTestNegativeBetweenTwoValues(allResult,testList, typeTab=["<double>","<float>"]):
+def checkTestNegativeBetweenTwoValues(allResult,testList, typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -490,8 +490,8 @@ def checkTestNegativeBetweenTwoValues(allResult,testList, typeTab=["<double>","<
         testName=test+RealType
         testCheck=assertRounding(testName)
         testCheck.assertNative()
-        testCheck.assertEqual("toward_zero","upward")
-        testCheck.assertLess("downward","upward")
+        testCheck.assertEqual("toward_zero", "upward")
+        testCheck.assertLess("downward", "upward")
         testCheck.assertLeq("downward", "nearest")
         testCheck.assertLeq("nearest", "upward")
 
@@ -501,19 +501,19 @@ def checkTestNegativeBetweenTwoValues(allResult,testList, typeTab=["<double>","<
         testCheck.assertLeq("downward", "random")
         testCheck.assertLeq("downward", "average")
 
-        testCheck.assertLeq("random","upward")
-        testCheck.assertLeq("average","upward")
+        testCheck.assertLeq("random", "upward")
+        testCheck.assertLeq("average", "upward")
 
         ok+=testCheck.ok
         ko+=testCheck.ko
         warn+=testCheck.warn
 
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
 
 
 
-def checkExact(allResult,testList,typeTab=["<double>","<float>"]):
+def checkExact(allResult,testList,typeTab=["<double>", "<float>"]):
     ok=0
     warn=0
     ko=0
@@ -523,8 +523,8 @@ def checkExact(allResult,testList,typeTab=["<double>","<float>"]):
 
             testCheck=assertRounding(testName)
             testCheck.assertNative()
-            testCheck.assertEqual("toward_zero","downward")
-            testCheck.assertEqual("downward","upward")
+            testCheck.assertEqual("toward_zero", "downward")
+            testCheck.assertEqual("downward", "upward")
             testCheck.assertEqual("upward", "nearest")
             testCheck.assertEqual("nearest", "upward")
 
@@ -537,7 +537,7 @@ def checkExact(allResult,testList,typeTab=["<double>","<float>"]):
             ko+=testCheck.ko
             warn+=testCheck.warn
 
-    return errorCounter(ok,ko,warn)
+    return errorCounter(ok, ko, warn)
 
 
 
@@ -545,35 +545,35 @@ if __name__=='__main__':
     cmdHandler=cmdPrepare("./"+sys.argv[1])
     allResult={}
     for (env, rounding) in generatePairOfAvailableComputation():
-        (cout,cerr)=cmdHandler.run(env,rounding)
+        (cout, cerr)=cmdHandler.run(env, rounding)
         if env=="valgrind":
-            allResult[(env ,rounding)]=(cout, verrouCerrFilter(cerr))
+            allResult[(env, rounding)]=(cout, verrouCerrFilter(cerr))
         else:
-            allResult[(env ,rounding)]=(cout,cerr)
+            allResult[(env, rounding)]=(cout, cerr)
             
     # printRes(allResult[("fenv" ,"toward_zero")])
     # printRes(allResult[("valgrind" ,"toward_zero")])
-    typeTab=["<double>","<float>"]#,"<long double>"]
+    typeTab=["<double>", "<float>"]#,"<long double>"]
 
     eCount=errorCounter()
 
     eCount+=checkVerrouInvariant(allResult)
 
 
-    eCount+=checkTestPositiveAndOptimistRandomVerrou(allResult, testList=["testInc0d1","testIncSquare0d1","testIncDiv10"], typeTab=typeTab)
-    eCount+=checkTestNegativeAndOptimistRandomVerrou(allResult, testList=["testInc0d1m","testIncSquare0d1m","testIncDiv10m"], typeTab=typeTab)
-    eCount+=checkTestPositive(allResult,testList=["testInvariantProdDiv"], typeTab=typeTab)
-    eCount+=checkTestNegative(allResult,testList=["testInvariantProdDivm"], typeTab=typeTab)
-    eCount+=checkTestPositiveAndOptimistRandomVerrou(allResult, testList=["testFma"], typeTab=["<double>","<float>"])
-    eCount+=checkTestNegativeAndOptimistRandomVerrou(allResult, testList=["testFmam"], typeTab=["<double>","<float>"])
+    eCount+=checkTestPositiveAndOptimistRandomVerrou(allResult, testList=["testInc0d1", "testIncSquare0d1", "testIncDiv10"], typeTab=typeTab)
+    eCount+=checkTestNegativeAndOptimistRandomVerrou(allResult, testList=["testInc0d1m", "testIncSquare0d1m", "testIncDiv10m"], typeTab=typeTab)
+    eCount+=checkTestPositive(allResult, testList=["testInvariantProdDiv"], typeTab=typeTab)
+    eCount+=checkTestNegative(allResult, testList=["testInvariantProdDivm"], typeTab=typeTab)
+    eCount+=checkTestPositiveAndOptimistRandomVerrou(allResult, testList=["testFma"], typeTab=["<double>", "<float>"])
+    eCount+=checkTestNegativeAndOptimistRandomVerrou(allResult, testList=["testFmam"], typeTab=["<double>", "<float>"])
         
-    eCount+=checkExact(allResult, testList=["testMixSseLlo"], typeTab=["<double>","<float>"])
+    eCount+=checkExact(allResult, testList=["testMixSseLlo"], typeTab=["<double>", "<float>"])
 
-    eCount+=checkExact(allResult, testList=["testCast","testCastm"], typeTab=["<double>"])
-    eCount+=checkTestPositiveBetweenTwoValues(allResult,testList=["testCast"], typeTab=["<float>"])
-    eCount+=checkTestNegativeBetweenTwoValues(allResult,testList=["testCastm"], typeTab=["<float>"])
+    eCount+=checkExact(allResult, testList=["testCast", "testCastm"], typeTab=["<double>"])
+    eCount+=checkTestPositiveBetweenTwoValues(allResult, testList=["testCast"], typeTab=["<float>"])
+    eCount+=checkTestNegativeBetweenTwoValues(allResult, testList=["testCastm"], typeTab=["<float>"])
 
-    eCount+=checkFloat(allResult,["testInc0d1","testIncSquare0d1","testIncDiv10","testInc0d1m","testIncSquare0d1m","testIncDiv10m","testFma", "testFmam", "testMixSseLlo"])
+    eCount+=checkFloat(allResult, ["testInc0d1", "testIncSquare0d1", "testIncDiv10", "testInc0d1m", "testIncSquare0d1m", "testIncDiv10m", "testFma", "testFmam", "testMixSseLlo"])
     eCount.printSummary()
     sys.exit(eCount.ko)
     #[0]

--- a/verrou_dd
+++ b/verrou_dd
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -u
+#!/usr/bin/env -S python3 -u
 
 import subprocess
 import sys

--- a/verrou_dd
+++ b/verrou_dd
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S python3 -u
+#!/usr/bin/env PYTHONUNBUFFERED=1 python3
 
 import subprocess
 import sys

--- a/verrou_dd
+++ b/verrou_dd
@@ -1,4 +1,6 @@
-#!/usr/bin/env PYTHONUNBUFFERED=1 python3
+#!/bin/sh
+''''exec python3 -u "$0" "$@" #'''
+# This hack is an ugly but portable alternative to #!/usr/bin/env -S python3 -u
 
 import subprocess
 import sys


### PR DESCRIPTION
Currently, the path to the python binary is hardcoded to `/usr/bin/python[3]`. This can fail if the python executable is not installed at this location. It is better to let PATH do its job by using env instead.