### PR TITLE
Fix installation prefix for shell completion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ completion_scripts=${completion_dir}/bash_completion_post_verrou_dd    ${complet
 		   ${completion_dir}/bash_completion_valgrind          ${completion_dir}/bash_completion_verrou_dd_line\
 		   ${completion_dir}/bash_completion_verrou_dd_sym     ${completion_dir}/bash_completion_verrou_plot_stat\
 		   ${completion_dir}/bash_completion_verrou_dd_back
-completion_install_dir=${prefix}/usr/share/completions
+completion_install_dir=${prefix}/share/completions
 
 # bash completion code generation
 # bash_completion_valgrind and ${completion_dir}/bash_completion_verrou_dd_clean are not generated

--- a/env.sh.in
+++ b/env.sh.in
@@ -12,7 +12,7 @@ export VERROU_COMPILED_WITH_QUADMATH=@vg_cv_verrou_quadmath@
 
 
 if [ "x${BASH_VERSION-}" != x ]; then
-    for bash_completion_file in @prefix@/usr/share/completions/bash_completion* ; do
+    for bash_completion_file in @prefix@/share/completions/bash_completion* ; do
 	[ -f "${bash_completion_file}" ] && . ${bash_completion_file}
     done
 fi


### PR DESCRIPTION
By default autotools sets `prefix=/usr/local`, so shell completion would end up in `/usr/local/usr/share/completions` instead of `/usr/local/share/completions`.