### PR TITLE
Fix linking error

### DIFF
--- a/vr_main.c
+++ b/vr_main.c
@@ -1137,7 +1137,7 @@ static HChar const * fnnoname=UNAMED_FUNCTION_VERROU;
 static HChar const * objnoname=UNAMED_OBJECT_VERROU;
 static HChar const * filenamenoname=UNAMED_FILENAME_VERROU;
 
-inline
+static inline
 void vr_treat_line_from_imark(traceBB_t* traceBB, Bool excludeIrsb, Bool includeSource,
                               Bool doLineContainFloat, Bool doLineContainFloatMod, Bool doLineContainFloatCmp,
                               HChar const *  fnname,   const HChar * filename, const UInt linenum){


### PR DESCRIPTION
Not sure why the compiler tries to link an inline function from within the same translation unit externally, but changing linkage to internal fixes the issue.

```
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: verrou_amd64_linux-vr_main.o: in function `vr_instrument':                                                                                                                                                                                           
/home/abuild/rpmbuild/BUILD/valgrind-3.26.0+verrou-2.7.0/verrou/vr_main.c:1385:(.text+0x16fb97): undefined reference to `vr_treat_line_from_imark'                                                                                                                                                                            
/usr/lib64/gcc/x86_64-suse-linux/7/../../../../x86_64-suse-linux/bin/ld: /home/abuild/rpmbuild/BUILD/valgrind-3.26.0+verrou-2.7.0/verrou/vr_main.c:1443:(.text+0x16ff45): undefined reference to `vr_treat_line_from_imark'                                                                                                   
collect2: error: ld returned 1 exit status
```