### PR TITLE
Interflop fixes

### DIFF
--- a/interflop/fma/interflop_fma.c
+++ b/interflop/fma/interflop_fma.c
@@ -11,6 +11,15 @@
  ****************************************************************************/
 
 #include "interflop_fma.h"
+
+#if defined(VGA_amd64) || defined(__x86_64__)
+#include  <immintrin.h>
+#endif
+
+#if defined(VGA_arm64) || defined(__aarch64__)
+#include "arm_neon.h"
+#endif
+
 #ifndef HAS_QUADMATH
 #include "pfp128.h"
 #endif

--- a/interflop_backends/interflop-backend-vprec/interflop_vprec.c
+++ b/interflop_backends/interflop-backend-vprec/interflop_vprec.c
@@ -892,7 +892,7 @@ void INTERFLOP_VPREC_API(user_call)(void *context, interflop_call_id id,
   }
 }
 
-void INTERFLOP_VPREC_API(finalize)([[maybe_unused]]void *context) {
+void INTERFLOP_VPREC_API(finalize)(void *context) {
 #ifndef IGNORE_VFI_CONTEXT
   vprec_context_t *ctx = (vprec_context_t *)context;
   _vfi_finalize(ctx);
@@ -1254,7 +1254,7 @@ static void print_information_header(void *context) {
 #endif
 }
 
-struct interflop_backend_interface_t INTERFLOP_VPREC_API(init)([[maybe_unused]] void *context) {
+struct interflop_backend_interface_t INTERFLOP_VPREC_API(init)(void *context) {
   /* initialize vprec function instrumentation context */
 #ifndef  IGNORE_VFI_CONTEXT
     vprec_context_t *ctx = (vprec_context_t *)context;


### PR DESCRIPTION
You might want to raise these issues with upstream.

1. Interflop makes use of the new `[[maybe_unused]]` attribute which was only added in C23. This in turn makes a C23-compatible compiler a hard requirement for compiling Verrou, which is probably not desired.
2. The file `interflop/fma/interflop_fma.c` is missing the required includes for vectorization intrinsics. I copied the corresponding include chunk from `interflop/sqrt/interflop_sqrt.c`.  However, note that `arm_neon.h` is missing from the repository, so Verrou probably cannot be built on ARM right now.